### PR TITLE
:lipstick: config: Add site title text color to match logo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -108,6 +108,7 @@ params:
   body_color: "#D8D1C9"
   text_color: "#777779"
   text_color_dark: "#374EA2"
+  text_title_color: "#264959ff"
   white_color: "#ffffff"
   light_color: "#f8f9fa"
 


### PR DESCRIPTION
This commit adds a new configuration value to change the color of the
title text color in the top navigation. The title text color now matches
the unicolor variant of the SustainOSS logo used on the site.

Related to unicef/inventory-hugo-theme#42.