### PR TITLE
:new: :memo: guidelines: Add reading list from UNICEF Inventory

### DIFF
--- a/content/guidelines/reading-list.en.md
+++ b/content/guidelines/reading-list.en.md
@@ -1,0 +1,21 @@
+---
+title: "Reading list"
+description: Various readings and learnings about design in an Open Source context.
+tags: ["reading list"]
+downloadBtn: "true"
+
+---
+
+Various readings and learnings about design and user experience.
+Usually with some kind of Open Source overlap or context.
+
+* [**Trauma & design PubPub**](https://hrcd.pubpub.org/pub/traumaanddesign):
+  Some basic definitions key to understanding the relationship between trauma and design.
+  Maintained by:
+    * [KJ Hepworth](https://hrcd.pubpub.org/user/katherine-hepworth)
+    * [Kat Lo](https://hrcd.pubpub.org/user/kat-lo)
+    * [Eriol Fox](https://hrcd.pubpub.org/user/eriol-fox)
+    * [Shirin Mori](https://hrcd.pubpub.org/user/s-o-2)
+* **[Ushahidi Open Design](https://github.com/Erioldoesdesign/opendesign), maintained by [Eriol Fox](https://erioldoesdesign.github.io/)**:
+  A collection of resources, notes, and other written content for distributed, asynchronous design contributions to software projects.
+  This content was originally created as part of a role with the [Ushahidi project](https://www.ushahidi.com/).


### PR DESCRIPTION
Closes unicef/inventory#83.

This commit imports the "Design & UX Reading List" from the UNICEF Open
Source Inventory. This moves the slim range of content on design from
the Inventory and into the SustainOSS Design portal. It also provides an
example of what a new article or post might look like.

Once this is added to the SustainOSS Design portal, the page and
category should be removed from the UNICEF Inventory to avoid
duplication of content.

![Screenshot of the reading list page in the Guidelines & Frameworks category.](https://user-images.githubusercontent.com/4721034/147148498-413116fb-40f4-4616-b045-8c450f5b2771.png "Screenshot of the reading list page in the Guidelines & Frameworks category.")

Note the blue navigation is a bug; this is fixed in unicef/inventory-hugo-theme#39.