### PR TITLE
:new: :two_hearts: .github: Opt in to SustainOSS Code of Conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# SustainOSS Code of Conduct
+
+This project opts in to the [SustainOSS Code of Conduct][coc-url].
+Please remember to keep your interactions and engagement in line with our community values and expectations.
+See the [Code of Conduct F.A.Q.][coc-faq-url] for more guidance and clarity.
+
+[coc-url]: https://sustainoss.org/code-of-conduct/
+[coc-faq-url]: https://sustainoss.org/code-of-conduct-faq/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ See the [maintainer's guide](https://unicef.github.io/inventory/meta/maintainers
 -->
 
 
+## :two_hearts: Code of Conduct
+
+This project adheres to the SustainOSS Code of Conduct.
+Find the full details [here](/.github/CODE_OF_CONDUCT.md).
+
+
 ## :memo: Legal
 
 This repository is primarily content, and it is licensed under a [Creative Commons Attribution ShareAlike 4.0 International License][cc-by-sa-legal].


### PR DESCRIPTION
This commit adds a Code of Conduct file to the repository, which then
points to the SustainOSS Code of Conduct on `sustainoss.org`. This our
explicit opt-in to the same CoC as the wider SustainOSS community.

Since we are already getting exposure and interest from folks beyond our
core Working Group team, I believe it is important we put this in place
now to explicitly state our values as a team and project, and to give
some intermediary advice on what to do if there are issues.

I request all maintainers to sign off with a review on this commit to
acknowledge this change.