### PR TITLE
:wrench: :link: config: Add menu link for SOS Design podcast

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -62,6 +62,10 @@ menu:
       weight: 10
       url: faq
 
+    - name: S.O.S. Design Podcast
+      weight: 12
+      url: https://sosdesign.sustainoss.org/
+
     - name: pages
       weight: 20
       url: pages


### PR DESCRIPTION
Related to #20 but does not close it.

This adds a new menu to the site. This causes the SOS Design podcast
link to show up at the top of the page but also in the footer too. It is
the easiest way to get more visibility for another site or URL.

![Screenshot of the Design Inventory home page. The podcast site appears in the top menu and the site footer.](https://user-images.githubusercontent.com/4721034/160763283-05ccfa10-cf71-4e9b-8670-93690448e7bf.png "Screenshot of the Design Inventory home page. The podcast site appears in the top menu and the site footer.")